### PR TITLE
allow suffixes to be set in locale

### DIFF
--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -34,24 +34,24 @@ function parseSuffixes(d, i) {
     @function formatAbbreviate
     @desc Formats a number to an appropriate number of decimal places and rounding, adding suffixes if applicable (ie. `1200000` to `"1.2M"`).
     @param {Number|String} n The number to be formatted.
-    @param {String} locale The locale to be formatted.
+    @param {Object|String} locale The locale config to be used. If *value* is an object, the function will format the numbers according the object. The object must include `suffixes`, `delimiter` and `currency` properties.
     @returns {String}
 */
-export default function(n, locale = "et") {
-  // isFinite
-  if (typeof n !== "number") n *= 1;
-  const specifier = "s";
-  const suffixes = defaultLocale[locale].suffixes.map(parseSuffixes);
+export default function(n, locale = "en-US") {
+  if (isFinite(n) && !isNaN(n)) n *= 1;
+  else return "N/A";
 
-  const length = n.toString().split(".")[0].replace("-", "").length;
+  const length = n.toString().split(".")[0].replace("-", "").length,
+        localeConfig = typeof locale === "object" ? locale : defaultLocale[locale] || defaultLocale["en-US"],
+        suffixes = localeConfig.suffixes.map(parseSuffixes);
+
   let val;
   if (n === 0) val = "0";
   else if (length >= 3) {
     const f = formatSuffix(n, 2, suffixes);
     const num = f.number;
     const char = f.symbol;
-    const prefix = specifier === "c" ? "$" : "";
-    val = `${prefix}${parseFloat(num)}${char}`;
+    val = `${parseFloat(num)}${char}`;
   }
   else if (length === 3) val = format(",f")(n);
   else if (n < 1 && n > -1) val = format(".2g")(n);

--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -45,13 +45,15 @@ export default function(n, locale = "en-US") {
         localeConfig = typeof locale === "object" ? locale : defaultLocale[locale] || defaultLocale["en-US"],
         suffixes = localeConfig.suffixes.map(parseSuffixes);
 
+  const separator = localeConfig.separator || "";
+
   let val;
   if (n === 0) val = "0";
   else if (length >= 3) {
     const f = formatSuffix(n, 2, suffixes);
     const num = f.number;
     const char = f.symbol;
-    val = `${parseFloat(num)}${char}`;
+    val = `${parseFloat(num)}${separator}${char}`;
   }
   else if (length === 3) val = format(",f")(n);
   else if (n < 1 && n > -1) val = format(".2g")(n);

--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -38,7 +38,7 @@ function parseSuffixes(d, i) {
     @returns {String}
 */
 export default function(n, locale = "en-US") {
-  if (isFinite(n) && !isNaN(n)) n *= 1;
+  if (isFinite(n)) n *= 1;
   else return "N/A";
 
   const length = n.toString().split(".")[0].replace("-", "").length,

--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -50,7 +50,7 @@ export default function(n, locale = "en-US") {
   let val;
   if (n === 0) val = "0";
   else if (length >= 3) {
-    const f = formatSuffix(n, 2, suffixes);
+    const f = formatSuffix(format(".3r")(n), 2, suffixes);
     const num = f.number;
     const char = f.symbol;
     val = `${parseFloat(num)}${separator}${char}`;

--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -1,25 +1,57 @@
 import {format} from "d3-format";
+import defaultLocale from "./locale.json";
+
+const round = (x, n) => 
+  parseFloat(Math.round(x * Math.pow(10, n)) / Math.pow(10, n)).toFixed(n);
+
+/** */
+function formatSuffix(value, precision, suffixes) {
+  let i = 0;
+  if (value) {
+    if (value < 0) value *= -1;
+    i = 1 + Math.floor(1e-12 + Math.log(value) / Math.LN10);
+    i = Math.max(-24, Math.min(24, Math.floor((i - 1) / 3) * 3));
+  }
+  const d = suffixes[8 + i / 3];
+  
+  return {
+    number: round(d.scale(value), precision),
+    symbol: d.symbol
+  };
+}
+
+/** */
+function parseSuffixes(d, i) {
+  const k = Math.pow(10, Math.abs(8 - i) * 3);
+  return {
+    scale: i > 8 ? d => d / k : d => d * k,
+    symbol: d
+  };
+}
+
 
 /**
     @function formatAbbreviate
     @desc Formats a number to an appropriate number of decimal places and rounding, adding suffixes if applicable (ie. `1200000` to `"1.2M"`).
-    @param {Number} n The number to be formatted.
+    @param {Number|String} n The number to be formatted.
+    @param {String} locale The locale to be formatted.
     @returns {String}
 */
-export default function(n) {
-  if (typeof n !== "number") return "N/A";
+export default function(n, locale = "et") {
+  // isFinite
+  if (typeof n !== "number") n *= 1;
+  const specifier = "s";
+  const suffixes = defaultLocale[locale].suffixes.map(parseSuffixes);
+
   const length = n.toString().split(".")[0].replace("-", "").length;
   let val;
   if (n === 0) val = "0";
   else if (length >= 3) {
-    const f = format(".3s")(n)
-      .replace("G", "B")
-      .replace("T", "t")
-      .replace("P", "q")
-      .replace("E", "Q");
-    const num = f.slice(0, -1);
-    const char = f.slice(f.length - 1);
-    val = `${parseFloat(num)}${char}`;
+    const f = formatSuffix(n, 2, suffixes);
+    const num = f.number;
+    const char = f.symbol;
+    const prefix = specifier === "c" ? "$" : "";
+    val = `${prefix}${parseFloat(num)}${char}`;
   }
   else if (length === 3) val = format(",f")(n);
   else if (n < 1 && n > -1) val = format(".2g")(n);

--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -45,11 +45,12 @@ export default function(n, locale = "en-US") {
         localeConfig = typeof locale === "object" ? locale : defaultLocale[locale] || defaultLocale["en-US"],
         suffixes = localeConfig.suffixes.map(parseSuffixes);
 
-  const separator = localeConfig.separator || "";
+  const decimal = localeConfig.delimiters.decimal || ".",
+        separator = localeConfig.separator || "";
 
   const d3plusFormatLocale = formatLocale({
     currency: localeConfig.currency || ["$", ""],
-    decimal: localeConfig.delimiters.decimal || ".",
+    decimal,
     grouping: localeConfig.grouping || [3],
     thousands: localeConfig.delimiters.thousands || ","
   });
@@ -58,9 +59,9 @@ export default function(n, locale = "en-US") {
   if (n === 0) val = "0";
   else if (length >= 3) {
     const f = formatSuffix(d3plusFormatLocale.format(".3r")(n), 2, suffixes);
-    const num = f.number;
+    const num = parseFloat(f.number).toString().replace(".", decimal);
     const char = f.symbol;
-    val = `${parseFloat(num)}${separator}${char}`;
+    val = `${num}${separator}${char}`;
   }
   else if (length === 3) val = d3plusFormatLocale.format(",f")(n);
   else if (n < 1 && n > -1) val = d3plusFormatLocale.format(".2g")(n);

--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -1,4 +1,4 @@
-import {format} from "d3-format";
+import {formatLocale} from "d3-format";
 import defaultLocale from "./locale.json";
 
 const round = (x, n) => 
@@ -47,17 +47,24 @@ export default function(n, locale = "en-US") {
 
   const separator = localeConfig.separator || "";
 
+  const d3plusFormatLocale = formatLocale({
+    currency: localeConfig.currency || ["$", ""],
+    decimal: localeConfig.delimiters.decimal || ".",
+    grouping: localeConfig.grouping || [3],
+    thousands: localeConfig.delimiters.thousands || ","
+  });
+
   let val;
   if (n === 0) val = "0";
   else if (length >= 3) {
-    const f = formatSuffix(format(".3r")(n), 2, suffixes);
+    const f = formatSuffix(d3plusFormatLocale.format(".3r")(n), 2, suffixes);
     const num = f.number;
     const char = f.symbol;
     val = `${parseFloat(num)}${separator}${char}`;
   }
-  else if (length === 3) val = format(",f")(n);
-  else if (n < 1 && n > -1) val = format(".2g")(n);
-  else val = format(".3g")(n);
+  else if (length === 3) val = d3plusFormatLocale.format(",f")(n);
+  else if (n < 1 && n > -1) val = d3plusFormatLocale.format(".2g")(n);
+  else val = d3plusFormatLocale.format(".3g")(n);
 
   return val
     .replace(/(\.[1-9]*)[0]*$/g, "$1") // removes any trailing zeros

--- a/src/locale.json
+++ b/src/locale.json
@@ -2,66 +2,60 @@
   "en-GB": {
     "separator": "",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
+    "grouping": [3],
     "delimiters": {
       "thousands": ",",
       "decimal": "."
     },
-    "currency": {
-      "symbol": "£"
-    }
+    "currency": ["£", ""]
   },
   "en-US": {
     "separator": "",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
+    "grouping": [3],
     "delimiters": {
       "thousands": ",",
       "decimal": "."
     },
-    "currency": {
-      "symbol": "$"
-    }
+    "currency": ["$", ""]
   },
   "es-ES": {
     "separator": "",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "mm", "b", "t", "q", "Q", "Z", "Y"],
+    "grouping": [3],
     "delimiters": {
       "thousands": ".",
       "decimal": ","
     },
-    "currency": {
-      "symbol": "€"
-    }
+    "currency": ["€", ""]
   },
   "es-CL": {
     "separator": "",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
+    "grouping": [3],
     "delimiters": {
       "thousands": ".",
       "decimal": ","
     },
-    "currency": {
-      "symbol": "$"
-    }
+    "currency": ["$", ""]
   },
   "et-EE": {
     "separator": " ",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "tuh", "mln", "mld", "trl", "q", "Q", "Z", "Y"],
+    "grouping": [3],
     "delimiters": {
       "thousands": " ",
       "decimal": ","
     },
-    "currency": {
-      "symbol": "€"
-    }
+    "currency": ["€", ""]
   },
   "fr-FR": {
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "m", "b", "t", "q", "Q", "Z", "Y"],
+    "grouping": [3],
     "delimiters": {
       "thousands": " ",
       "decimal": ","
     },
-    "currency": {
-      "symbol": "€"
-    }
+    "currency": ["€", ""]
   }
 }

--- a/src/locale.json
+++ b/src/locale.json
@@ -1,5 +1,6 @@
 {
   "en-GB": {
+    "separator": "",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
     "delimiters": {
       "thousands": ",",
@@ -10,6 +11,7 @@
     }
   },
   "en-US": {
+    "separator": "",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
     "delimiters": {
       "thousands": ",",
@@ -20,6 +22,7 @@
     }
   },
   "es-ES": {
+    "separator": "",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "mm", "b", "t", "q", "Q", "Z", "Y"],
     "delimiters": {
       "thousands": ".",
@@ -30,6 +33,7 @@
     }
   },
   "es-LA": {
+    "separator": "",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
     "delimiters": {
       "thousands": ".",
@@ -40,6 +44,7 @@
     }
   },
   "et": {
+    "separator": " ",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "tuh", "mln", "mld", "trl", "q", "Q", "Z", "Y"],
     "delimiters": {
       "thousands": " ",

--- a/src/locale.json
+++ b/src/locale.json
@@ -32,7 +32,7 @@
       "symbol": "€"
     }
   },
-  "es-LA": {
+  "es-CL": {
     "separator": "",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
     "delimiters": {
@@ -43,7 +43,7 @@
       "symbol": "$"
     }
   },
-  "et": {
+  "et-EE": {
     "separator": " ",
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "tuh", "mln", "mld", "trl", "q", "Q", "Z", "Y"],
     "delimiters": {
@@ -54,7 +54,7 @@
       "symbol": "€"
     }
   },
-  "fr": {
+  "fr-FR": {
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "m", "b", "t", "q", "Q", "Z", "Y"],
     "delimiters": {
       "thousands": " ",

--- a/src/locale.json
+++ b/src/locale.json
@@ -1,8 +1,38 @@
 {
-  "en": {
+  "en-GB": {
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
     "delimiters": {
-      "thousands": " ",
+      "thousands": ",",
+      "decimal": "."
+    },
+    "currency": {
+      "symbol": "£"
+    }
+  },
+  "en-US": {
+    "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
+    "delimiters": {
+      "thousands": ",",
+      "decimal": "."
+    },
+    "currency": {
+      "symbol": "$"
+    }
+  },
+  "es-ES": {
+    "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "mm", "b", "t", "q", "Q", "Z", "Y"],
+    "delimiters": {
+      "thousands": ".",
+      "decimal": ","
+    },
+    "currency": {
+      "symbol": "€"
+    }
+  },
+  "es-LA": {
+    "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
+    "delimiters": {
+      "thousands": ".",
       "decimal": ","
     },
     "currency": {
@@ -11,6 +41,16 @@
   },
   "et": {
     "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "tuh", "mln", "mld", "trl", "q", "Q", "Z", "Y"],
+    "delimiters": {
+      "thousands": " ",
+      "decimal": ","
+    },
+    "currency": {
+      "symbol": "€"
+    }
+  },
+  "fr": {
+    "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "m", "b", "t", "q", "Q", "Z", "Y"],
     "delimiters": {
       "thousands": " ",
       "decimal": ","

--- a/src/locale.json
+++ b/src/locale.json
@@ -1,0 +1,22 @@
+{
+  "en": {
+    "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
+    "delimiters": {
+      "thousands": " ",
+      "decimal": ","
+    },
+    "currency": {
+      "symbol": "$"
+    }
+  },
+  "et": {
+    "suffixes": ["y", "z", "a", "f", "p", "n", "µ", "m", "", "tuh", "mln", "mld", "trl", "q", "Q", "Z", "Y"],
+    "delimiters": {
+      "thousands": " ",
+      "decimal": ","
+    },
+    "currency": {
+      "symbol": "€"
+    }
+  }
+}

--- a/test/abbreviate.js
+++ b/test/abbreviate.js
@@ -20,8 +20,10 @@ test("abbreviate", assert => {
   assert.equal("1B",    abbreviate(1000000009), "large - removes trailing zeros and period");
   assert.equal("0.1",   abbreviate(0.1), "small - removes trailing zeros");
 
-  assert.equal("10 mln", abbreviate(10000000, "et-EE"), "estonian locale");
-  assert.equal("1mm",    abbreviate(1000000, "es-ES"), "spanish locale");
+  assert.equal("10 mln",   abbreviate(10000000, "et-EE"), "estonian locale");
+  assert.equal("1,23 trl", abbreviate(1234567890000, "et-EE"), "trillion in estonian");
+  assert.equal("1mm",      abbreviate(1000000, "es-ES"), "spanish locale");
+  assert.equal("1,23t",    abbreviate(1234567890000, "es-ES"), "trillion in spanish");
 
 });
 

--- a/test/abbreviate.js
+++ b/test/abbreviate.js
@@ -8,8 +8,8 @@ test("abbreviate", assert => {
   assert.equal("1.23t", abbreviate(1234567890000), "trillion");
   assert.equal("1.23B", abbreviate(1234567890), "billion");
   assert.equal("1.23M", abbreviate(1234567), "million");
-  assert.equal("123.46k",  abbreviate(123456), "hundred thousand");
-  assert.equal("12.35k", abbreviate(12345), "ten thousand");
+  assert.equal("123k",  abbreviate(123456), "hundred thousand");
+  assert.equal("12.3k", abbreviate(12345), "ten thousand");
   assert.equal("1.23k", abbreviate(1234), "thousand");
   assert.equal("123",   abbreviate(123), "hundred");
   assert.equal("12",    abbreviate(12), "ten");
@@ -19,6 +19,9 @@ test("abbreviate", assert => {
 
   assert.equal("1B",    abbreviate(1000000009), "large - removes trailing zeros and period");
   assert.equal("0.1",   abbreviate(0.1), "small - removes trailing zeros");
+
+  assert.equal("10 mln", abbreviate(10000000, "et-EE"), "estonian locale");
+  assert.equal("1mm",    abbreviate(1000000, "es-ES"), "spanish locale");
 
 });
 

--- a/test/abbreviate.js
+++ b/test/abbreviate.js
@@ -8,8 +8,8 @@ test("abbreviate", assert => {
   assert.equal("1.23t", abbreviate(1234567890000), "trillion");
   assert.equal("1.23B", abbreviate(1234567890), "billion");
   assert.equal("1.23M", abbreviate(1234567), "million");
-  assert.equal("123k",  abbreviate(123456), "hundred thousand");
-  assert.equal("12.3k", abbreviate(12345), "ten thousand");
+  assert.equal("123.46k",  abbreviate(123456), "hundred thousand");
+  assert.equal("12.35k", abbreviate(12345), "ten thousand");
   assert.equal("1.23k", abbreviate(1234), "thousand");
   assert.equal("123",   abbreviate(123), "hundred");
   assert.equal("12",    abbreviate(12), "ten");


### PR DESCRIPTION
(closes #2)

<!--- Provide a general summary of your changes in the title above -->
This PR allows customize the suffixes of the numbers that will be set using the locale. It includes support for +10 locales, and the user will can set its custom suffixes.

### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [x] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

