### PR TITLE
includes format property as param

### DIFF
--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -41,7 +41,7 @@ function parseSuffixes(d, i) {
     @param {Object|String} locale The locale config to be used. If *value* is an object, the function will format the numbers according the object. The object must include `suffixes`, `delimiter` and `currency` properties.
     @returns {String}
 */
-export default function(n, locale = "en-US", format = undefined) {
+export default function(n, locale = "en-US") {
   if (isFinite(n)) n *= 1;
   else return "N/A";
 
@@ -57,7 +57,7 @@ export default function(n, locale = "en-US", format = undefined) {
     currency: localeConfig.currency || ["$", ""],
     decimal,
     grouping: localeConfig.grouping || [3],
-    thousands: localeConfig.delimiters.thousands || ","
+    thousands
   });
 
   let val;
@@ -71,8 +71,6 @@ export default function(n, locale = "en-US", format = undefined) {
   else if (length === 3) val = d3plusFormatLocale.format(",f")(n);
   else if (n < 1 && n > -1) val = d3plusFormatLocale.format(".2g")(n);
   else val = d3plusFormatLocale.format(".3g")(n);
-
-  if (format && format === "%") val = `${d3plusFormatLocale.format(".2g")(n * 100)}%`;
 
   return val
     .replace(/(\.[1-9]*)[0]*$/g, "$1") // removes any trailing zeros

--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -41,7 +41,7 @@ function parseSuffixes(d, i) {
     @param {Object|String} locale The locale config to be used. If *value* is an object, the function will format the numbers according the object. The object must include `suffixes`, `delimiter` and `currency` properties.
     @returns {String}
 */
-export default function(n, locale = "en-US") {
+export default function(n, locale = "en-US", format = undefined) {
   if (isFinite(n)) n *= 1;
   else return "N/A";
 
@@ -50,7 +50,8 @@ export default function(n, locale = "en-US") {
         suffixes = localeConfig.suffixes.map(parseSuffixes);
 
   const decimal = localeConfig.delimiters.decimal || ".",
-        separator = localeConfig.separator || "";
+        separator = localeConfig.separator || "",
+        thousands = localeConfig.delimiters.decimal || ",";
 
   const d3plusFormatLocale = formatLocale({
     currency: localeConfig.currency || ["$", ""],
@@ -63,13 +64,15 @@ export default function(n, locale = "en-US") {
   if (n === 0) val = "0";
   else if (length >= 3) {
     const f = formatSuffix(d3plusFormatLocale.format(".3r")(n), 2, suffixes);
-    const num = parseFloat(f.number).toString().replace(".", decimal);
+    const num = parseFloat(f.number).toString().replace(".", thousands);
     const char = f.symbol;
     val = `${num}${separator}${char}`;
   }
   else if (length === 3) val = d3plusFormatLocale.format(",f")(n);
   else if (n < 1 && n > -1) val = d3plusFormatLocale.format(".2g")(n);
   else val = d3plusFormatLocale.format(".3g")(n);
+
+  if (format && format === "%") val = `${d3plusFormatLocale.format(".2g")(n * 100)}%`;
 
   return val
     .replace(/(\.[1-9]*)[0]*$/g, "$1") // removes any trailing zeros


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Currently, `formatAbbreviate` didn't include support for `share|rate` numbers, and likewise for their locale formats. With this PR, you can include the `format` property as param in `formatAbbreviate`. 

```
formatAbbreviate(0.012, "et-EE", "%")  -> 1,2%
```

PS: In the future, I hope to include new formats accepted, as "$"
### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

