### PR TITLE
includes round argument to formatAbbreviate

### DIFF
--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -41,7 +41,7 @@ function parseSuffixes(d, i) {
     @param {Object|String} locale The locale config to be used. If *value* is an object, the function will format the numbers according the object. The object must include `suffixes`, `delimiter` and `currency` properties.
     @returns {String}
 */
-export default function(n, locale = "en-US") {
+export default function(n, locale = "en-US", round = true) {
   if (isFinite(n)) n *= 1;
   else return "N/A";
 
@@ -51,7 +51,7 @@ export default function(n, locale = "en-US") {
 
   const decimal = localeConfig.delimiters.decimal || ".",
         separator = localeConfig.separator || "",
-        thousands = localeConfig.delimiters.decimal || ",";
+        thousands = localeConfig.delimiters.thousands || ",";
 
   const d3plusFormatLocale = formatLocale({
     currency: localeConfig.currency || ["$", ""],
@@ -62,6 +62,9 @@ export default function(n, locale = "en-US") {
 
   let val;
   if (n === 0) val = "0";
+  else if (length >= 3 & !round) {
+    val = d3plusFormatLocale.format(`,.${length}r`)(n);
+  }
   else if (length >= 3) {
     const f = formatSuffix(d3plusFormatLocale.format(".3r")(n), 2, suffixes);
     const num = parseFloat(f.number).toString().replace(".", thousands);

--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -67,7 +67,7 @@ export default function(n, locale = "en-US", round = true) {
   }
   else if (length >= 3) {
     const f = formatSuffix(d3plusFormatLocale.format(".3r")(n), 2, suffixes);
-    const num = parseFloat(f.number).toString().replace(".", thousands);
+    const num = parseFloat(f.number).toString().replace(".", decimal);
     const char = f.symbol;
     val = `${num}${separator}${char}`;
   }

--- a/src/abbreviate.js
+++ b/src/abbreviate.js
@@ -41,7 +41,7 @@ function parseSuffixes(d, i) {
     @param {Object|String} locale The locale config to be used. If *value* is an object, the function will format the numbers according the object. The object must include `suffixes`, `delimiter` and `currency` properties.
     @returns {String}
 */
-export default function(n, locale = "en-US", round = true) {
+export default function(n, locale = "en-US", precision = undefined) {
   if (isFinite(n)) n *= 1;
   else return "N/A";
 
@@ -61,10 +61,8 @@ export default function(n, locale = "en-US", round = true) {
   });
 
   let val;
-  if (n === 0) val = "0";
-  else if (length >= 3 & !round) {
-    val = d3plusFormatLocale.format(`,.${length}r`)(n);
-  }
+  if (precision) val = d3plusFormatLocale.format(precision)(n);
+  else if (n === 0) val = "0";
   else if (length >= 3) {
     const f = formatSuffix(d3plusFormatLocale.format(".3r")(n), 2, suffixes);
     const num = parseFloat(f.number).toString().replace(".", decimal);

--- a/test/abbreviate.js
+++ b/test/abbreviate.js
@@ -25,6 +25,9 @@ test("abbreviate", assert => {
   assert.equal("1mm",      abbreviate(1000000, "es-ES"), "spanish locale");
   assert.equal("1,23t",    abbreviate(1234567890000, "es-ES"), "trillion in spanish");
 
+  assert.equal("1,000", abbreviate(1000, "en-US", false), "trillion in estonian");
+  assert.equal("1 000", abbreviate(1000, "et-EE", false), "trillion in estonian");
+
 });
 
 export default test;

--- a/test/abbreviate.js
+++ b/test/abbreviate.js
@@ -25,8 +25,10 @@ test("abbreviate", assert => {
   assert.equal("1mm",      abbreviate(1000000, "es-ES"), "spanish locale");
   assert.equal("1,23t",    abbreviate(1234567890000, "es-ES"), "trillion in spanish");
 
-  assert.equal("1,000", abbreviate(1000, "en-US", false), "trillion in estonian");
-  assert.equal("1 000", abbreviate(1000, "et-EE", false), "trillion in estonian");
+  assert.equal("0.12", abbreviate(0.12, "en-US"), "decimal format in english");
+  assert.equal("0,12", abbreviate(0.12, "et-EE"), "decimal format in estonian");
+  assert.equal("1,000", abbreviate(1000, "en-US", ",.4r"), "trillion in english");
+  assert.equal("1 000", abbreviate(1000, "et-EE", ",.4r"), "trillion in estonian");
 
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
### Description
<!--- Describe your changes in detail -->
This new feature includes a boolean argument called `round`. If `round: false`, `formatAbbreviate` only format the number, avoiding to round it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

