### PR TITLE
creates locale formatter for es-MX

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -32,6 +32,26 @@ export default {
     },
     currency: ["$", ""]
   },
+  "es-CL": {
+    separator: "",
+    suffixes: ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "MM", "B", "T", "Q", "Z", "Y"],
+    grouping: [3],
+    delimiters: {
+      thousands: ".",
+      decimal: ","
+    },
+    currency: ["$", ""]
+  },
+  "es-MX": {
+    separator: "",
+    suffixes: ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "MM", "B", "T", "Q", "Z", "Y"],
+    grouping: [3],
+    delimiters: {
+      thousands: ",",
+      decimal: "."
+    },
+    currency: ["$", ""]
+  },
   "es-ES": {
     separator: "",
     suffixes: ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "mm", "b", "t", "q", "Q", "Z", "Y"],
@@ -41,16 +61,6 @@ export default {
       decimal: ","
     },
     currency: ["€", ""]
-  },
-  "es-CL": {
-    separator: "",
-    suffixes: ["y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "B", "t", "q", "Q", "Z", "Y"],
-    grouping: [3],
-    delimiters: {
-      thousands: ".",
-      decimal: ","
-    },
-    currency: ["$", ""]
   },
   "et-EE": {
     separator: " ",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes #8 

This PR includes the locale formatter for es-MX, using `long-scale system` [https://www.languagesandnumbers.com/articles/en/long-and-short-numeric-scales/](https://www.languagesandnumbers.com/articles/en/long-and-short-numeric-scales/)

### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

